### PR TITLE
Fix/mxmetaobject

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -482,6 +482,7 @@ declare module mx {
         ): void;
         synchronizeDataWithFiles(successCallback: () => void, failureCallback: (error: Error)=>void): void;
         synchronizeOffline(options: { fast: boolean }, successCallback: () => void, failureCallback: (error: Error)=>void): void;
+        getDocumentUrl(guid: string, changedDate: number, isThumbnail?: boolean): string;
     }
 
     interface meta {

--- a/index.d.ts
+++ b/index.d.ts
@@ -414,6 +414,8 @@ declare module mx {
             }
         }, scope?: Object): void;
         getBacktrackConstraints(metaObject: any, context: any, callback: (xpath: string, allMatched: boolean) => void): void;
+        getDocumentUrl(guid: string, changedDate: number, isThumbnail?: boolean): string;
+        getImageUrl(url: string, callback: (objectUrl: string) => void, error?: (error: Error) => void): void;
         release(objects: mendix.lib.MxObject | mendix.lib.MxObject[]): void;
         remove(arg: {
             guid?: string,
@@ -482,7 +484,6 @@ declare module mx {
         ): void;
         synchronizeDataWithFiles(successCallback: () => void, failureCallback: (error: Error)=>void): void;
         synchronizeOffline(options: { fast: boolean }, successCallback: () => void, failureCallback: (error: Error)=>void): void;
-        getDocumentUrl(guid: string, changedDate: number, isThumbnail?: boolean): string;
     }
 
     interface meta {


### PR DESCRIPTION
getEnumMap() contains a parameter attribute of type sting which is not included in the typings 