### PR TITLE
Cleanup client typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -628,7 +628,7 @@ declare namespace mx {
         getTemplate(mxid: string, content: string): DocumentFragment;
         showLogin(messageCode: number): void;
         reload(callback?: () => void): void;
-        translate(lib: string, errorName: string): string;
+        translate(lib: string, errorName: string, values?: any[]): string;
     }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -222,7 +222,7 @@ declare namespace mxui {
             _msgNode: HTMLElement;
             _messages: any[];
             add(message: string, modal: boolean): number;
-            remove(msgId: number): void;
+            remove(messageId: number): void;
         }
     }
 
@@ -592,11 +592,11 @@ declare namespace mx {
         /**
          * Shows an error message.
          */
-        error(msg: string, modal?: boolean): void;
+        error(message: string, modal?: boolean): void;
         /**
          * Shows a message for a fatal error in a modal dialog.
          */
-        exception(msg: string): void;
+        exception(message: string): void;
         /**
          *
          */
@@ -608,7 +608,7 @@ declare namespace mx {
         /**
          * Shows an information message.
          */
-        info(msg: string, modal: boolean): void;
+        info(message: string, modal: boolean): void;
         onError(error: Error): void;
         showUnderlay(delay?: number): void;
         hideUnderlay(delay?: number): void;
@@ -628,7 +628,7 @@ declare namespace mx {
         getTemplate(mxid: string, content: string): DocumentFragment;
         showLogin(messageCode: number): void;
         reload(callback?: () => void): void;
-        translate(lib: string, errorName: string, values?: any[]): string;
+        translate(systemTextCategory: string, systemTextItem: string, parameterValues?: any[]): string;
     }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -495,11 +495,11 @@ declare namespace mx {
             attr: string
         }): void;
         saveDocument(guid: string,
-                     name: string,
-                     params: { width?: number, height?: number },
-                     blob: Blob,
-                     callback: () => void,
-                     error: (error: Error) => void
+            name: string,
+            params: { width?: number, height?: number },
+            blob: Blob,
+            callback: () => void,
+            error: (error: Error) => void
         ): void;
         synchronizeDataWithFiles(successCallback: () => void, failureCallback: (error: Error) => void): void;
         synchronizeOffline(options: { fast: boolean }, successCallback: () => void, failureCallback: (error: Error) => void): void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mendix-clieWnt-typing",
+  "name": "mendix-client",
   "version": "7.4.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -12,9 +12,295 @@
       "version": "https://registry.npmjs.org/@types/dojo/-/dojo-1.9.35.tgz",
       "integrity": "sha1-JYdOU2VvS1dtXFLHEdv+An2F8U4="
     },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
     "big.js": {
       "version": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
       "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+      "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+      "dev": true,
+      "requires": {
+        "esutils": "1.1.6",
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "esutils": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+          "dev": true
+        }
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "tslib": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
+      "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw=",
+      "dev": true
+    },
+    "tslint": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.7.0.tgz",
+      "integrity": "sha1-wl4NDJL6EgHCvDDoROCOaCtPNVI=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "colors": "1.1.2",
+        "commander": "2.11.0",
+        "diff": "3.3.1",
+        "glob": "7.1.2",
+        "minimatch": "3.0.4",
+        "resolve": "1.4.0",
+        "semver": "5.4.1",
+        "tslib": "1.7.1",
+        "tsutils": "2.11.2"
+      }
+    },
+    "tslint-eslint-rules": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-4.1.1.tgz",
+      "integrity": "sha1-fDDniC8mvCdr/5HSOEl1xp2viLo=",
+      "dev": true,
+      "requires": {
+        "doctrine": "0.7.2",
+        "tslib": "1.7.1",
+        "tsutils": "1.9.1"
+      },
+      "dependencies": {
+        "tsutils": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-1.9.1.tgz",
+          "integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA=",
+          "dev": true
+        }
+      }
+    },
+    "tsutils": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.11.2.tgz",
+      "integrity": "sha1-YBNgHjb6FP+VhBPlQdQn+4xqw0E=",
+      "dev": true,
+      "requires": {
+        "tslib": "1.7.1"
+      }
+    },
+    "typescript": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
+      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mendix-client",
-  "version": "7.4.1",
+  "version": "7.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,18 @@
   "version": "7.4.1",
   "types": "index.d.ts",
   "scripts": {
-    "test": "tsc"
+    "test": "tsc",
+    "lint": "tslint index.d.ts -c tslint.json",
+    "lint:fix": "npm run lint -- --fix"
   },
   "dependencies": {
     "@types/big.js": "0.0.31",
-    "@types/dojo": "^1.9.34",
-    "big.js": "^3.1.3"
+    "@types/dojo": "^1.9.34"
+  },
+  "devDependencies": {
+    "tslint": "^5.7.0",
+    "tslint-eslint-rules": "^4.1.1",
+    "big.js": "^3.1.3",
+    "typescript": "^2.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mendix-client",
   "author": "Andries Smit <andries.smit@flockofbirds.org>",
   "description": "Typescript type definition for Mendix client",
-  "version": "7.4.1",
+  "version": "7.6.0",
   "types": "index.d.ts",
   "scripts": {
     "test": "tsc",

--- a/tests/mx-test.ts
+++ b/tests/mx-test.ts
@@ -121,17 +121,46 @@ mx.data.get({
         console.log("Received " + objects.length + " MxObjects");
     }
 });
+// Deprecated
+// mx.data.getBacktrackConstraints(null, someContext, function (xpath, allMatched) {
+//     if (allMatched) {
+//         console.log("All backtracking constraints were met, xpath is: " + xpath);
+//     } else {
+//         console.log("Some backtracking constraints could not be met");
+//     }
+// });
 
-mx.data.getBacktrackConstraints(null, someContext, function (xpath, allMatched) {
-    if (allMatched) {
-        console.log("All backtracking constraints were met, xpath is: " + xpath);
-    } else {
-        console.log("Some backtracking constraints could not be met");
-    }
+mx.data.getOffline("MyFirstModule.Pet", null, null, function(mxobjs, count) {
+    console.log("There are " + count + " pets");
 });
 
-mx.data.release(obj) // releases a single object
-mx.data.release([obj, obj]) // releases two objects
+mx.data.getOffline("MyFirstModule.Pet", [ {
+        attribute: "MyFirstModule.Pet_Person",
+        operator: "equals",
+        value: "1234" // the guid of the owner, which is a Person entity
+    } ], null, function (mxobjs, count) {
+        console.log("There are " + count + " pets referring to owner 1234");
+    }
+);
+
+mx.data.getOffline("MyFirstModule.Pet", [{
+            attribute: "Name",
+            operator: "contains",
+            value: "ed"
+        }, {
+            attribute: "Age",
+            operator: "greaterThan",
+            value: 2
+        }], {
+        offset: 15,
+        limit: 5,
+        sort: [["Name", "asc"], ["Age", "desc"]]
+    }, function (mxobjs, count) {
+        console.log("Pets that matched your filter: " + mxobjs.length);
+        console.log("Pets that matched your query: " + count);
+    }, function (e) {
+        console.error("Could not retrieve slice:", e);
+});
 
 mx.data.remove({
     guid: "123456",
@@ -163,12 +192,13 @@ mx.data.rollback({
     }
 });
 
-mx.data.save({
-    mxobj: obj,
-    callback: function () {
-        console.log("ok");
-    }
-});
+// Deprecated
+// mx.data.save({
+//     mxobj: obj,
+//     callback: function () {
+//         console.log("ok");
+//     }
+// });
 
 var fileBlob = new Blob();
 mx.data.saveDocument("123456", "Bunnies.jpg", { width: 180, height: 180 }, fileBlob, function () {
@@ -256,6 +286,30 @@ mx.ui.exception("Some exception");
 mx.ui.error("Some Info", true);
 
 mx.ui.getTemplate("12", "content"); // Template 'content' for widget with mxid '12'
+// Based on https://apidocs.mendix.com/7/client/mxui_lib_form__FormBase.html
+// Disable all child widgets of the form (you would normally use .enable() for this).
+form.callRecursive("set", form.disable, true);
+
+form.close();
+
+mx.ui.openForm("MyFirstModule/Puppies.page.xml", {
+    location: "popup",
+    callback: function(form) {
+        // List all direct child widgets in the popup.
+        console.log(form.getChildren());
+
+        // List all child widgets in the popup.
+        console.log(form.getChildren(true));
+    }
+});
+
+form.listen("commit", function(callback, error) {
+    callback();
+});
+
+this.connect(this.mxform, form.onNavigation, function() {
+   // custom logic
+});
 
 mx.ui.openForm("MyFirstModule/Puppies.page.xml", {
     location: "popup",

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,116 @@
+{
+  "rulesDirectory": [ "node_modules/tslint-eslint-rules/dist/rules" ],
+  "extends": "tslint:latest",
+  "rules": {
+    "class-name": false,
+    "comment-format": [ true, "check-space" ],
+    "eofline": true,
+    "indent": [ true, "spaces", 4 ],
+    "member-ordering": [ true, "variables-before-functions" ],
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-conditional-assignment": true,
+    "no-console": [ true ],
+    "no-debugger": true,
+    "no-duplicate-variable": true,
+    "no-eval": true,
+    "no-inferrable-types": [ true ],
+    "no-internal-module": true,
+    "no-shadowed-variable": true,
+    "no-switch-case-fall-through": true,
+    "no-trailing-whitespace": true,
+    "no-unused-expression": true,
+    "no-var-keyword": true,
+    "one-line": [
+      true,
+      "check-catch",
+      "check-finally",
+      "check-else",
+      "check-open-brace",
+      "check-whitespace"
+    ],
+    "quotemark": [ true, "double" ],
+    "semicolon": [ true, "always" ],
+    "triple-equals": [ true, "allow-null-check" ],
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      }
+    ],
+    "variable-name": [ true, "ban-keywords" ],
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-module",
+      "check-separator",
+      "check-type"
+    ],
+    "interface-name": [ false, "always-prefix" ],
+    "no-multi-spaces": [ true ],
+    "no-submodule-imports": [
+      true,
+      "dijit/registry",
+      "dojo/_base/connect",
+      "dojo/aspect"
+    ],
+    "no-extra-semi": true,
+    "no-irregular-whitespace": true,
+    "no-duplicate-case": true,
+    "no-control-regex": true,
+    "no-empty-character-class": true,
+    "no-ex-assign": true,
+    "no-extra-boolean-cast": true,
+    "no-unexpected-multiline": true,
+    "no-sparse-arrays": true,
+    "no-regex-spaces": true,
+    "no-invalid-regexp": true,
+    "valid-typeof": true,
+    "array-bracket-spacing": [ true, "always" ],
+    "block-spacing": [ true, "always" ],
+    "brace-style": [
+      true,
+      "1tbs",
+      {
+        "allowSingleLine": true
+      }
+    ],
+    "object-curly-spacing": [ true, "always" ],
+    "trailing-comma": [
+      true,
+      {
+        "multiline": "never",
+        "singleline": "never"
+      }
+    ],
+    "member-access": false,
+    "ordered-imports": [
+      true,
+      {
+        "import-sources-order": "any",
+        "named-imports-order": "lowercase-last"
+      }
+    ],
+    "curly": false,
+    "max-line-length": [ false ],
+    "arrow-parens": false,
+    "no-namespace": false,
+    "array-type": [ false ],
+    "max-classes-per-file": [ false ],
+    "unified-signatures": false,
+    "align": [ true, "arguments", "elements", "members", "statements" ],
+    "ban-types": [ true,
+      ["Function", "Avoid using the `Function` type. Prefer a specific function type, like `() => void`."],
+      ["Boolean", "Avoid using the `Boolean` type. Did you mean `boolean`?"],
+      ["Number", "Avoid using the `Number` type. Did you mean `number`?"],
+      ["String", "Avoid using the `String` type. Did you mean `string`?"],
+      ["Symbol", "Avoid using the `Symbol` type. Did you mean `symbol`?"]
+    ]
+  }
+}


### PR DESCRIPTION
- Linted 
- Make parameter names better readable (Renamed acronyms)
- Removed deprecation.
- Specified types previous `any` and `Function`
- Add some missing types like; session.isGuest()